### PR TITLE
Fix tests when lib is not installed

### DIFF
--- a/t/015-sanity.t
+++ b/t/015-sanity.t
@@ -19,8 +19,8 @@ if !library-exists('sndfile', v1) {
 }
 
 my $test-output = "t/test-output".IO;
-
 $test-output.mkdir unless $test-output.d;
+END { $test-output and rm_rf $test-output }
 
 my $rc;
 
@@ -133,9 +133,5 @@ compare-arrays(@doubles-in, @doubles);
 lives-ok { $double-obj-in.close }, "close that";
 
 done-testing;
-
-END {
-       rm_rf $test-output.Str;
-}
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/020-write.t
+++ b/t/020-write.t
@@ -16,8 +16,8 @@ if !library-exists('sndfile', v1) {
 }
 
 my $test-output = "t/test-output".IO;
-
 $test-output.mkdir unless $test-output.d;
+END { $test-output and rm_rf $test-output }
 
 my @tests = (
                 {
@@ -312,9 +312,5 @@ for @tests.pick(*) -> $file {
 }
 
 done-testing;
-
-END {
-    rm_rf $test-output.Str;
-}
 
 # vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
The END block runs at the end of program, and when exiting due to the library not
being present, that happens before $test-output has any value in it, triggering
"Must specify something as a path: did you mean '.' for the current directory" error
from .IO coercer in `rm_rf`